### PR TITLE
restore idle timeout to configured value instead of fixed 10 minutes

### DIFF
--- a/Klipper Config/Orbiter2_SmartSensor.cfg
+++ b/Klipper Config/Orbiter2_SmartSensor.cfg
@@ -2,8 +2,8 @@
 ################################# Orbiter Sensor CONFIGURATION ##################################################
 #################################################################################################################
 
-#config file version v3.2.0
-#release date: 17.07.2025
+#config file version v3.2.1
+#release date: 10.02.2026
 
 # PAUSE, RESUME and CANCEL macros are defined at the end of this config file.
 # If you prefer using your own, please delete them, otherwise define parking position below.
@@ -314,7 +314,7 @@ gcode:
     G1 E{e} F2100
     G90    
     M118 O2S: Temperatures restored, resmume printing!
-    SET_IDLE_TIMEOUT TIMEOUT=600 # restor klipper default printer timeout to 10 min
+    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout} # restore configured printer idle timeout
     RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1
     BASE_RESUME    
    # SET_LED LED=OrbiLED RED=1.0 GREEN=1.0 BLUE=1.0
@@ -325,7 +325,7 @@ gcode:
     CLEAR_PAUSE
     SDCARD_RESET_FILE
     BASE_CANCEL_PRINT 
-    SET_IDLE_TIMEOUT TIMEOUT=600 # restor klipper default printer timeout to 10 min
+    SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout} # restore configured printer idle timeout
 
 [gcode_macro T0]
 gcode:

--- a/Klipper Config/readme.md
+++ b/Klipper Config/readme.md
@@ -1,6 +1,6 @@
-Changes v3.1.0
+Changes v3.2.1
 - Included CANCEL macro for user using the sensor macros instead of their own macros
-- Pausing printer due to tangle or runnout detection increases printer timeout to 3600s - 1h (configurable by pause_timeout), timeout set back to default ten minutes after print resume.
+- Pausing printer due to tangle or runnout detection increases printer timeout to 3600s - 1h (configurable by pause_timeout), timeout set back to configured value after print resume.
 - improved temperature restore behavior
 - Filament automatic unload after runnout can be disabled by variable disable_autochange.
 - messages sent to console show OS2: prefix


### PR DESCRIPTION
Hey there 😃
I've adjusted the macros to set the idle timeout back to the configured value instead of klippers default value of 10 minutes. With this change you don't have to mess around with any timeout values at all.
It's just something I personally prefer. Just igore this PR if you don't like it. 👍

Best regards Niko ✌️